### PR TITLE
Fix context menu location

### DIFF
--- a/src/lib/contextMenuContent.component.ts
+++ b/src/lib/contextMenuContent.component.ts
@@ -115,12 +115,12 @@ export class ContextMenuContentComponent implements OnInit, OnDestroy, AfterView
         setTimeout(() => {
           const menuWidth = this.menuElement ? this.menuElement.nativeElement.clientWidth : 100;
           const menuHeight = this.menuElement ? this.menuElement.nativeElement.clientHeight : 100;
-          const bodyWidth = this.event.view.innerWidth;
-          const bodyHeight = this.event.view.innerHeight;
-          const distanceFromRight = bodyWidth - (this.event.clientX + menuWidth);
-          const distanceFromBottom = bodyHeight - (this.event.clientY + menuHeight);
+          const viewportWidth = this.event.view.innerWidth;
+          const viewportHeight = this.event.view.innerHeight;
+          const distanceFromRight = viewportWidth - (this.event.clientX + menuWidth);
+          const distanceFromBottom = viewportHeight - (this.event.clientY + menuHeight);
           let isMenuOutsideBody = false;
-          if (distanceFromRight < 0 && this.event.clientX > bodyWidth / 2) {
+          if (distanceFromRight < 0 && this.event.clientX > viewportWidth / 2) {
             this.mouseLocation.marginLeft = '-' + menuWidth + 'px';
             if (this.parentContextMenu) {
               this.mouseLocation.marginLeft = '-' + (menuWidth + this.parentContextMenu.menuElement.nativeElement.clientWidth) + 'px';
@@ -128,7 +128,7 @@ export class ContextMenuContentComponent implements OnInit, OnDestroy, AfterView
             isMenuOutsideBody = true;
           }
           if (distanceFromBottom < 0) {
-            if (this.event.clientY > bodyHeight / 2) {
+            if (this.event.clientY > viewportHeight / 2) {
               this.mouseLocation.marginTop = '-' + menuHeight + 'px';
             } else {
               this.mouseLocation.top = this.event.clientY + distanceFromBottom + 'px';

--- a/src/lib/contextMenuContent.component.ts
+++ b/src/lib/contextMenuContent.component.ts
@@ -115,8 +115,8 @@ export class ContextMenuContentComponent implements OnInit, OnDestroy, AfterView
         setTimeout(() => {
           const menuWidth = this.menuElement ? this.menuElement.nativeElement.clientWidth : 100;
           const menuHeight = this.menuElement ? this.menuElement.nativeElement.clientHeight : 100;
-          const bodyWidth = this.event.view.document.body.clientWidth;
-          const bodyHeight = this.event.view.document.body.clientHeight;
+          const bodyWidth = this.event.view.innerWidth;
+          const bodyHeight = this.event.view.innerHeight;
           const distanceFromRight = bodyWidth - (this.event.clientX + menuWidth);
           const distanceFromBottom = bodyHeight - (this.event.clientY + menuHeight);
           let isMenuOutsideBody = false;
@@ -127,10 +127,12 @@ export class ContextMenuContentComponent implements OnInit, OnDestroy, AfterView
             }
             isMenuOutsideBody = true;
           }
-          if (distanceFromBottom < 0 && this.event.clientY > bodyHeight / 2) {
-            this.mouseLocation.marginTop = '-' + menuHeight + 'px';
-            isMenuOutsideBody = true;
-          }
+          if (distanceFromBottom < 0) {
+            if (this.event.clientY > bodyHeight / 2) {
+              this.mouseLocation.marginTop = '-' + menuHeight + 'px';
+            } else {
+              this.mouseLocation.top = this.event.clientY + distanceFromBottom + 'px';
+            }
           if (isMenuOutsideBody) {
             this.showMenu();
           }


### PR DESCRIPTION
Hello Isaac,

I am using your ngx-context menu and now I have a situation when it works not good.
In my case:
- page height is 872px (document.body.clientHeight = 872 px);
- browser window height is 759 px (window.innerWidth = 759 px);
- mouse location clientY = 466px;
- menu height = 389 px.
"clientY" and "clientX" calculation starts from browser border but "bodyHeight" calculation depends on document body height. So context menu is cut - it shows to bottom from mouse location.

My fix provides changes for:

1. Avoid context menu cutting - new calculation of bodyHeight and bodyWidth.
2. If menu can not be shown in top or bottom without cutting - it will be displaying in bottom, but moving to top for avoid cutting - this.mouseLocation.top = this.event.clientY + distanceFromBottom + 'px'.

The same you can do with horizontal context menu location.

Best regards,
Volodymyr