### PR TITLE
Injection Token

### DIFF
--- a/src/lib/contextMenu.options.ts
+++ b/src/lib/contextMenu.options.ts
@@ -1,7 +1,8 @@
-import { OpaqueToken } from '@angular/core';
+import { InjectionToken } from '@angular/core';
+
+export const CONTEXT_MENU_OPTIONS = new InjectionToken<IContextMenuOptions>('CONTEXT_MENU_OPTIONS');
 
 export interface IContextMenuOptions {
   useBootstrap4?: boolean;
   autoFocus?: boolean;
 }
-export const CONTEXT_MENU_OPTIONS = new OpaqueToken('CONTEXT_MENU_OPTIONS');


### PR DESCRIPTION
InjectionToken Extends the Opaque class. This means that while this will work for Angular 4.0.x and 5.0.x this should break support on 2.0.x I am unable to verify. 

Demo verified working on v4 and v5 unable to verify functionality on v2. 