### PR TITLE
When context menu is disabled display browser default context menu

### DIFF
--- a/projects/ngx-contextmenu/src/lib/contextMenu.attach.directive.ts
+++ b/projects/ngx-contextmenu/src/lib/contextMenu.attach.directive.ts
@@ -13,12 +13,14 @@ export class ContextMenuAttachDirective {
 
   @HostListener('contextmenu', ['$event'])
   public onContextMenu(event: MouseEvent): void {
-    this.contextMenuService.show.next({
-      contextMenu: this.contextMenu,
-      event,
-      item: this.contextMenuSubject,
-    });
-    event.preventDefault();
-    event.stopPropagation();
+    if (!this.contextMenu.disabled) {
+      this.contextMenuService.show.next({
+        contextMenu: this.contextMenu,
+        event,
+        item: this.contextMenuSubject,
+      });
+      event.preventDefault();
+      event.stopPropagation();
+    }
   }
 }


### PR DESCRIPTION
Resolves #133 

![](http://g.recordit.co/ZkMHD0ZVED.gif)

When context menu is not disabled -> Display ngx-contextmenu.

When context is disabled -> Display browser default contextmenu.

I appreciate that it maybe desired behaviour to disable the context menu all together, so open for opinions on how this should work but having the ability to enable the browsers original context menu would be good I assume?