### PR TITLE
fix: allow angular 8 peer dependency

### DIFF
--- a/projects/ngx-contextmenu/package.json
+++ b/projects/ngx-contextmenu/package.json
@@ -18,8 +18,8 @@
     "url": "git+ssh://git@github.com/isaacplmann/ngx-contextmenu.git"
   },
   "peerDependencies": {
-    "@angular/cdk": "^6.0.0 || ^7.0.0",
-    "@angular/common": "^6.0.0 || ^7.0.0",
-    "@angular/core": "^6.0.0 || ^7.0.0"
+    "@angular/cdk": ">=6.0.0 <9.0.0",
+    "@angular/common": ">=6.0.0 <9.0.0",
+    "@angular/core": ">=6.0.0 <9.0.0"
   }
 }


### PR DESCRIPTION
Angular 8 is coming, so this patch allows the angular 8 peer dependency

Thanks for your work on this library! 😄